### PR TITLE
fixed documentation issue where two input pins were swapped

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -18,7 +18,7 @@ documentation:
   discord:      ""      # Your discord handle
   title:        "8x8 Bit Pattern Player"      # Project title
   description:  "8x8 bit serial programmable, addressable and playable memory."      # Short description of what your project does
-  how_it_works: "The 8x8 memory is a 64-bit shiftregister, consisting of 64 serial chained D-FlipFlops (data: IN0, clk_sr: IN1). 8 memoryslots of each 8 bit can be directly addressed via addresslines (3 bit: IN2, IN3, IN4) or from a clockdriven player (3 bit counter, clk_pl: IN7). A mode selector line (mode: IN5) sets the operation mode to addressing or to player. The 8 outputs are driven by the 8 bit of the addressed memoryslot."      # Longer description of how the project works
+  how_it_works: "The 8x8 memory is a 64-bit shiftregister, consisting of 64 serial chained D-FlipFlops (clk_sr: IN0, data: IN1). 8 memoryslots of each 8 bit can be directly addressed via addresslines (3 bit: IN2, IN3, IN4) or from a clockdriven player (3 bit counter, clk_pl: IN7). A mode selector line (mode: IN5) sets the operation mode to addressing or to player. The 8 outputs are driven by the 8 bit of the addressed memoryslot."      # Longer description of how the project works
   how_to_test:  "Programm the memory: Start by filling the 64 bit shiftregister via data and clk_sr, each rising edge on clk_sr shifts a new data bit into the register. Select mode: Set mode input for direct addressing or clockdriven player. Address mode: Address a memoryslot via the three addresslines and watch the memoryslot at the outputs. Player mode: Each rising edge at clk_pl enables the next memoryslot to the outputs."      # Instructions on how someone could test your project, include things like what buttons do what and how to set the clock if needed
   external_hw:  "You could programm, address and play the 8x8 Bit Pattern Player with a breadboard, two clock buttons and some dipswitches on the input side. Add some LED to the output side. Just like the WOKWI simulation."      # Describe any external hardware needed
   language:     "wokwi" # other examples include Verilog, Amaranth, VHDL, etc
@@ -26,8 +26,8 @@ documentation:
   clock_hz:     0       # Clock frequency in Hz (if required)
   picture:      "pattern_player.png"      # relative path to a picture in your repository
   inputs:
-    - data
     - clk_sr
+    - data
     - address_0
     - address_1
     - address_2


### PR DESCRIPTION
Input pins 0 and 1 (write clock and serial data in) were incorrectly swapped in the documentation.